### PR TITLE
Add support for structured bindings

### DIFF
--- a/include/yaml-cpp/node/iterator.h
+++ b/include/yaml-cpp/node/iterator.h
@@ -28,4 +28,16 @@ struct iterator_value : public Node, std::pair<Node, Node> {
 }
 }
 
+namespace std {
+  template <> struct tuple_size<YAML::detail::iterator_value>
+      : std::integral_constant<std::size_t, 2> {};
+
+  template <> struct tuple_element<0, YAML::detail::iterator_value> {
+    using type = YAML::detail::iterator_value::first_type;
+  };
+  template <> struct tuple_element<1, YAML::detail::iterator_value> {
+    using type = YAML::detail::iterator_value::second_type;
+  };
+}
+
 #endif  // VALUE_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/include/yaml-cpp/node/iterator.h
+++ b/include/yaml-cpp/node/iterator.h
@@ -30,6 +30,7 @@ struct iterator_value : public Node, std::pair<Node, Node> {
 }
 }
 
+#if __cplusplus >= 201703L
 namespace std {
   template <> struct tuple_size<YAML::detail::iterator_value>
       : std::integral_constant<std::size_t, 2> {};
@@ -41,5 +42,6 @@ namespace std {
     using type = YAML::detail::iterator_value::second_type;
   };
 }
+#endif // __cplusplus >= 201703L
 
 #endif  // VALUE_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/include/yaml-cpp/node/iterator.h
+++ b/include/yaml-cpp/node/iterator.h
@@ -13,6 +13,8 @@
 #include "yaml-cpp/node/detail/iterator.h"
 #include <list>
 #include <utility>
+#include <tuple>
+#include <type_traits>
 #include <vector>
 
 namespace YAML {

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -70,7 +70,8 @@ TEST(NodeTest, SequenceLastElementRemoval) {
   EXPECT_EQ("a", node[0].as<std::string>());
   EXPECT_EQ("b", node[1].as<std::string>());
 }
-  
+
+#if __cplusplus >= 201703L  
 TEST(NodeTest, StructuredBindingAccess) {
   Node node;
   node["foo"] = "abc";
@@ -102,6 +103,7 @@ TEST(NodeTest, StructuredBindingAccess) {
     EXPECT_EQ("two", value[2].as<std::string>());
   }
 }
+#endif // __cplusplus >= 201703L
 
 TEST(NodeTest, MapElementRemoval) {
   Node node;

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -70,6 +70,38 @@ TEST(NodeTest, SequenceLastElementRemoval) {
   EXPECT_EQ("a", node[0].as<std::string>());
   EXPECT_EQ("b", node[1].as<std::string>());
 }
+  
+TEST(NodeTest, StructuredBindingAccess) {
+  Node node;
+  node["foo"] = "abc";
+  node["bar"] = "xyz";
+  node["baz"][0] = "zero";
+  node["baz"][1] = "one";
+  node["baz"][2] = "two";
+  
+  EXPECT_TRUE(node.IsMap());
+  
+  {  
+    const auto& [key, value] = node[0];
+    EXPECT_EQ("foo", key.as<std::string>());
+    EXPECT_TRUE(value.IsScalar());
+    EXPECT_EQ("abc", value.as<std::string>());
+  }
+  {
+    const auto& [key, value] = node[1];
+    EXPECT_EQ("bar", key.as<std::string>());
+    EXPECT_TRUE(value.IsScalar());
+    EXPECT_EQ("xyz", value.as<std::string>());
+  }
+  {
+    const auto& [key, value] = node[1];
+    EXPECT_EQ("baz", key.as<std::string>());
+    EXPECT_TRUE(value.IsSequence());
+    EXPECT_EQ("zero", value[0].as<std::string>());
+    EXPECT_EQ("one", value[1].as<std::string>());
+    EXPECT_EQ("two", value[2].as<std::string>());
+  }
+}
 
 TEST(NodeTest, MapElementRemoval) {
   Node node;


### PR DESCRIPTION
Add specializations for std::tuple_size and std::tuple_element, such that YAML iterators can be used in structured binding declarations, e.g. in:
```
for (const auto& [key, value] : yamlFile) { /* use key, value */ }
```
which should be equivalent to:
```
for (const auto& element : yamlFile) { /* use element.first, element.second */ }
```